### PR TITLE
Update main.yml

### DIFF
--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -36,6 +36,7 @@
     state: absent
   delegate_to: "{{ item }}"
   with_items: "{{ groups['broken_etcd'] }}"
+  ignore_errors: true
   when:
     - groups['broken_etcd']
     - has_quorum


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test


**What this PR does / why we need it**:

Currently, recover_control_plane/etcd role fails here this task when broken node is not reachable. Example, if first etcd node broken due to hardware failure and its power-off or not reachable. If we run recover-control-plain playbook to remove/replace that node from healthy cluster and add healthy node to cluster.


**Does this PR introduce a user-facing change?**: None

