### PR TITLE
Remove the duplicate task for etcd cert dir creation

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -18,18 +18,6 @@
   when: inventory_hostname == groups['etcd'][0]
   delegate_to: "{{ groups['etcd'][0] }}"
 
-- name: "Gen_certs | create etcd cert dir (on {{ groups['etcd'][0] }})"
-  file:
-    path: "{{ etcd_cert_dir }}"
-    group: "{{ etcd_cert_group }}"
-    state: directory
-    owner: kube
-    recurse: yes
-    mode: 0700
-  run_once: yes
-  when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{ groups['etcd'][0] }}"
-
 - name: Gen_certs | write openssl config
   template:
     src: "openssl.conf.j2"


### PR DESCRIPTION
ETCD cert dir is being created in the first task in this file always and hence third task which is intended to create etcd cert dir on first etcd node is not required because first task creates the dir on first etcd node also.


**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
This reduces the duplication of ansible task.

**Special notes for your reviewer**:
