### PR TITLE
Update etcd without rotating etcd certs

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -313,6 +313,12 @@ Upgrade etcd:
 ansible-playbook -b -i inventory/sample/hosts.ini cluster.yml --tags=etcd
 ```
 
+Upgrade etcd without rotating etcd certs:
+
+```ShellSession
+ansible-playbook -b -i inventory/sample/hosts.ini cluster.yml --tags=etcd --limit=etcd --skip-tags=etcd-secrets
+```
+
 Upgrade kubelet:
 
 ```ShellSession


### PR DESCRIPTION
A deployer may want to upgrade specific components with certain restriction ex. upgrade etcd without rotating etcd certs.
This helps deployer while upgrading Kubernetes in modular way. If something fails deployer exactly know where it is failing and so super easy to find why.

**What type of PR is this?**
> /kind documentation

**Does this PR introduce a user-facing change?**: NONE
